### PR TITLE
Use cropsinsilico images, where custom images are necessary

### DIFF
--- a/cis.sh
+++ b/cis.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # Start Kubernetes
-./kube.sh
+#./kube.sh
 
 # Location of "kubectl" binary
-BINDIR="$HOME/bin"
+BINDIR="/usr/bin"
 ECHO="echo -e"
 
 $ECHO ''
@@ -13,7 +13,7 @@ $ECHO ''
 DOMAIN="*.cis.ndslabs.org"
 
 # Locations of source code / TLS certs
-SRC_DIR="/home/core/Cis_Repository"
+SRC_DIR="/home/ubuntu/Cis_Repository"
 CRT_DIR="${SRC_DIR}/kubernetes"
 
 # Stop everything first

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,24 +5,24 @@ services:
   # Framework / Models
   cis-interface:
     build: ./framework/
-    image: bodom0015/cis_interface
+    image: cropsinsilico/cis_interface
 
   # IDE
   cis-cloud9:
     build:
       context: ./platform/
       dockerfile: Dockerfile.cloud9
-    image: bodom0015/cloud9-cis
+    image: cropsinsilico/cloud9
     
   # Platform
   cis-ui:
     build: 
       context: https://github.com/cropsinsilico/cis-ui.git
-    image: bodom0015/cis-ui
+    image: cropsinsilico/cis-ui
   cis-api:
     build: 
       context: https://github.com/cropsinsilico/cis-apiserver.git
-    image: bodom0015/cis-apiserver
+    image: cropsinsilico/cis-apiserver
   noflo-ui:
     image: flowhub/noflo-ui
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,15 +19,11 @@ services:
     build: 
       context: https://github.com/cropsinsilico/cis-ui.git
     image: cropsinsilico/cis-ui
-  cis-api:
-    build: 
-      context: https://github.com/cropsinsilico/cis-apiserver.git
-    image: cropsinsilico/cis-apiserver
-  noflo-ui:
-    image: flowhub/noflo-ui
     ports:
-     - "9999:9999"
-  cis-rabbitmq:
-    image: "rabbit:3.6.12"
-    ports: 
-     - "5672:5672"
+     - "80:80"
+  girder:
+    build:
+      context: https://github.com/cropsinsilico/cis-girder-plugin
+    image: cropsinsilico/girder:latest
+    ports:
+     - "8080:8080"

--- a/platform/girder.yaml
+++ b/platform/girder.yaml
@@ -73,14 +73,16 @@ spec:
         hostPath:
           path: /home/core/cis-ui
       containers:
-      - image: bodom0015/cis-ui
+      - image: cropsinsilico/cis-ui
+        imagePullPolicy: Always
         name: cis-ui
         ports:
         - containerPort: 80
         volumeMounts:
         - name: uisrc
           mountPath: /usr/share/nginx/html
-      - image: girder/girder:2.3.0
+      - image: cropsinsilico/girder:2.3.0
+        imagePullPolicy: Always
         name: girder
         ports:
         - containerPort: 8080
@@ -88,6 +90,7 @@ spec:
         - name: pluginsrc
           mountPath: /girder/plugins/cis
       - image: mongo:3.3
+        imagePullPolicy: Always
         name: mongo
         ports:
         - containerPort: 27017


### PR DESCRIPTION
Created a new [cropsinsilico DockerHub organization](https://hub.docker.com/r/cropsinsilico/) to house the official Docker images used in the project.

If I were an administrator on the GitHub organization, I could automate all of these Docker builds as well.