### PR TITLE
Fixed ServiceAccount pattern in Girder YAML

### DIFF
--- a/platform/girder.dev.yaml
+++ b/platform/girder.dev.yaml
@@ -3,6 +3,12 @@ kind: Namespace
 metadata:
   name: cis-dev
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cis
+  namespace: cis-dev
+---
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/platform/girder.prod.yaml
+++ b/platform/girder.prod.yaml
@@ -1,7 +1,13 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: cis-prod
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
   name: cis
+  namespace: cis-prod
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -11,14 +17,14 @@ metadata:
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     certmanager.k8s.io/cluster-issuer: letsencrypt-prod
   name: cis-girder
-  namespace: cis
+  namespace: cis-prod
 spec:
   tls:
   - hosts:
-    - cis.ndslabs.org
+    - prod.cis.ndslabs.org
     secretName: cis-tls-secret
   rules:
-  - host: cis.ndslabs.org
+  - host: prod.cis.ndslabs.org
     http:
       paths:
       - path: /
@@ -44,7 +50,7 @@ metadata:
   labels:
     component: cis-girder
   name: cis-girder
-  namespace: cis
+  namespace: cis-prod
 spec:
   ports:
   - name: http
@@ -60,7 +66,7 @@ metadata:
   labels:
     component: cis-girder
   name: cis-girder
-  namespace: cis
+  namespace: cis-prod
 spec:
   replicas: 1
   template:

--- a/platform/girder.staging.yaml
+++ b/platform/girder.staging.yaml
@@ -3,6 +3,12 @@ kind: Namespace
 metadata:
   name: cis-staging
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cis
+  namespace: cis-staging
+---
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/platform/rbac/cis.clusterrolebinding.yaml
+++ b/platform/rbac/cis.clusterrolebinding.yaml
@@ -6,7 +6,13 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: cis
+  namespace: cis
+- kind: ServiceAccount
+  name: cis
   namespace: cis-dev
+- kind: ServiceAccount
+  name: cis
+  namespace: cis-staging
 roleRef:
   kind: ClusterRole
   name: job-submission

--- a/platform/rbac/cis.serviceaccount.yaml
+++ b/platform/rbac/cis.serviceaccount.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cis
-  namespace: cis-staging


### PR DESCRIPTION
# Problem
`girder.*.yaml` creates a namespace where the Pod expects a ServiceAccount to already exist - Pod fails to create since ServiceAccount does not yet exist

This should fix the YAML to create the ServiceAccount after the Namespace, but before the Pod.